### PR TITLE
bugfix: saving DeepSAD model with pretrain=False

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ scikit-learn==0.21.2
 scipy==1.3.0
 seaborn==0.9.0
 six==1.12.0
-torch==1.1.0
-torchvision==0.3.0
+torch>=1.1.0
+torchvision>=0.3.0

--- a/src/DeepSAD.py
+++ b/src/DeepSAD.py
@@ -60,7 +60,7 @@ class DeepSAD(object):
 
     def train(self, dataset: BaseADDataset, optimizer_name: str = 'adam', lr: float = 0.001, n_epochs: int = 50,
               lr_milestones: tuple = (), batch_size: int = 128, weight_decay: float = 1e-6, device: str = 'cuda',
-              n_jobs_dataloader: int = 0):
+              n_jobs_dataloader: int = 0, validate : bool = False):
         """Trains the Deep SAD model on the training data."""
 
         self.optimizer_name = optimizer_name
@@ -68,8 +68,9 @@ class DeepSAD(object):
                                       lr_milestones=lr_milestones, batch_size=batch_size, weight_decay=weight_decay,
                                       device=device, n_jobs_dataloader=n_jobs_dataloader)
         # Get the model
-        self.net = self.trainer.train(dataset, self.net)
+        self.net = self.trainer.train(dataset, self.net, validate=validate)
         self.results['train_time'] = self.trainer.train_time
+        self.train_loss = self.trainer.train_loss
         self.c = self.trainer.c.cpu().data.numpy().tolist()  # get as list
 
     def test(self, dataset: BaseADDataset, device: str = 'cuda', n_jobs_dataloader: int = 0):

--- a/src/DeepSAD.py
+++ b/src/DeepSAD.py
@@ -130,7 +130,7 @@ class DeepSAD(object):
         """Save Deep SAD model to export_model."""
 
         net_dict = self.net.state_dict()
-        ae_net_dict = self.ae_net.state_dict() if save_ae else None
+        ae_net_dict = self.ae_net.state_dict() if (save_ae and self.ae_net is not None) else None
 
         torch.save({'c': self.c,
                     'net_dict': net_dict,

--- a/src/optim/DeepSAD_trainer.py
+++ b/src/optim/DeepSAD_trainer.py
@@ -28,15 +28,16 @@ class DeepSADTrainer(BaseTrainer):
 
         # Results
         self.train_time = None
+        self.train_loss = None
         self.test_auc = None
         self.test_time = None
         self.test_scores = None
 
-    def train(self, dataset: BaseADDataset, net: BaseNet):
+    def train(self, dataset: BaseADDataset, net: BaseNet, validate: bool = False):
         logger = logging.getLogger()
 
         # Get train data loader
-        train_loader, _ = dataset.loaders(batch_size=self.batch_size, num_workers=self.n_jobs_dataloader)
+        train_loader, test_loader = dataset.loaders(batch_size=self.batch_size, num_workers=self.n_jobs_dataloader)
 
         # Set device for network
         net = net.to(self.device)
@@ -57,13 +58,14 @@ class DeepSADTrainer(BaseTrainer):
         logger.info('Starting training...')
         start_time = time.time()
         net.train()
+        self.train_loss = []
         for epoch in range(self.n_epochs):
 
             scheduler.step()
             if epoch in self.lr_milestones:
                 logger.info('  LR scheduler: new learning rate is %g' % float(scheduler.get_lr()[0]))
 
-            epoch_loss = 0.0
+            train_epoch_loss = 0.0
             n_batches = 0
             epoch_start_time = time.time()
             for data in train_loader:
@@ -81,13 +83,39 @@ class DeepSADTrainer(BaseTrainer):
                 loss.backward()
                 optimizer.step()
 
-                epoch_loss += loss.item()
+                train_epoch_loss += loss.item()
                 n_batches += 1
 
+            train_loss = train_epoch_loss/n_batches
+            epoch_loss_history = (epoch + 1, train_loss)
+
+            if validate:
+                n_batches = 0
+                test_epoch_loss = 0.0
+                with torch.set_grad_enabled(False):
+                    for data in test_loader:
+                        inputs, _, semi_targets, _ = data
+                        inputs, semi_targets = inputs.to(self.device), semi_targets.to(self.device)
+
+                        outputs = net(inputs)
+                        dist = torch.sum((outputs - self.c) ** 2, dim=1)
+                        losses = torch.where(semi_targets == 0, dist, self.eta * ((dist + self.eps) ** semi_targets.float()))
+                        loss = torch.mean(losses)
+
+                        test_epoch_loss += loss.item()
+                        n_batches += 1
+                test_loss = test_epoch_loss/n_batches
+                epoch_loss_history = (epoch + 1, train_loss, test_loss)
+
+            self.train_loss.append(epoch_loss_history)
             # log epoch statistics
             epoch_train_time = time.time() - epoch_start_time
-            logger.info(f'| Epoch: {epoch + 1:03}/{self.n_epochs:03} | Train Time: {epoch_train_time:.3f}s '
-                        f'| Train Loss: {epoch_loss / n_batches:.6f} |')
+
+            stats = f'| Epoch: {epoch + 1:03}/{self.n_epochs:03} | Train Time: {epoch_train_time:.3f}s ' \
+                f'| Train Loss: {train_loss:.6f}'
+            if validate:
+                stats = stats + f' | Validation Loss: {test_loss:.6f}'
+            logger.info(stats)
 
         self.train_time = time.time() - start_time
         logger.info('Training Time: {:.3f}s'.format(self.train_time))

--- a/src/optim/DeepSAD_trainer.py
+++ b/src/optim/DeepSAD_trainer.py
@@ -46,13 +46,13 @@ class DeepSADTrainer(BaseTrainer):
         optimizer = optim.Adam(net.parameters(), lr=self.lr, weight_decay=self.weight_decay)
 
         # Set learning rate scheduler
-        scheduler = optim.lr_scheduler.MultiStepLR(optimizer, milestones=self.lr_milestones, gamma=0.1)
+        self.scheduler = optim.lr_scheduler.MultiStepLR(optimizer, milestones=self.lr_milestones, gamma=0.1)
 
         # Initialize hypersphere center c (if c not loaded)
         if self.c is None:
             logger.info('Initializing center c...')
             self.c = self.init_center_c(train_loader, net)
-            logger.info('Center c initialized.')
+            logger.info('Center c initialized to {}.'.format(self.c))
 
         # Training
         logger.info('Starting training...')
@@ -61,9 +61,9 @@ class DeepSADTrainer(BaseTrainer):
         self.train_loss = []
         for epoch in range(self.n_epochs):
 
-            scheduler.step()
+            self.scheduler.step()
             if epoch in self.lr_milestones:
-                logger.info('  LR scheduler: new learning rate is %g' % float(scheduler.get_lr()[0]))
+                logger.info('  LR scheduler: new learning rate is %g' % float(self.scheduler.get_lr()[0]))
 
             train_epoch_loss = 0.0
             n_batches = 0


### PR DESCRIPTION
Before the fix, saving the model failed when `pretrain` was set to `False`, with the following error:
```
  File "/Deep-SAD-PyTorch/src/DeepSAD.py", line 133, in save_model
    ae_net_dict = self.ae_net.state_dict() if save_ae else None
AttributeError: 'NoneType' object has no attribute 'state_dict'
```
This fix checks that `self.ae_net` is not None before saving the autoencoder.